### PR TITLE
common: workaround bug with Ubuntu and GCC 5.4...

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -116,9 +116,13 @@ if (MSVC)
 	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /MP /D_CRT_SECURE_NO_WARNINGS /DNVML_UTF8_API /DGTEST_LANG_CXX11")
 	include_directories($ENV{PMDK_IncludePath})
 else ()
+	# Sets WORKAROUND_FLAGS variable which contains flags required to build with current configuration
+	check_workaround_flags_required()
+
 	# Disable RPATH so LD_LIBRARY_PATH can be used
 	set(CMAKE_SKIP_RPATH ON)
-	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Drestrict=__restrict__ -Werror -Wall -Wextra -pedantic-errors -Wpedantic -std=c++11")
+
+	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Drestrict=__restrict__ -Werror -Wall -Wextra -pedantic-errors -Wpedantic -std=c++11 ${WORKAROUND_FLAGS}")
 endif ()
 
 include(src/CMakeLists.txt)

--- a/functions.cmake
+++ b/functions.cmake
@@ -1,5 +1,5 @@
 #
-# Copyright 2017, Intel Corporation
+# Copyright 2017-2018, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -147,4 +147,28 @@ function(download_pugixml)
 	endif ()
 
 	include_directories(SYSTEM "${CMAKE_CURRENT_BINARY_DIR}/ext/pugixml/src/pugixml/src")
+endfunction()
+
+include(CheckCXXSourceCompiles)
+function(check_workaround_flags_required)
+	# Workaround for a bug in Ubuntu 17.10 and its GCC 5.4
+	# issue link : https://bugs.launchpad.net/ubuntu/+source/gcc-5/+bug/1739778
+	check_cxx_source_compiles("
+		#include <string>
+		#include <iostream>
+
+		int main()
+		{
+			std::cout << std::to_string(4) << std::endl;
+			return 0;
+		}
+	"
+	D_GLIBCXX_USE_C99_NOT_REQUIRED)
+
+	set(WORKAROUND_FLAGS "")
+	if (NOT D_GLIBCXX_USE_C99_NOT_REQUIRED)
+		set(WORKAROUND_FLAGS "${WORKAROUND_FLAGS} -D_GLIBCXX_USE_C99")
+	endif ()
+
+	set(WORKAROUND_FLAGS "${WORKAROUND_FLAGS}" PARENT_SCOPE)
 endfunction()


### PR DESCRIPTION
...when compiling - std::to_string and other C++11 members are not defined

Issue link : https://bugs.launchpad.net/ubuntu/+source/gcc-5/+bug/1739778

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk-tests/4)
<!-- Reviewable:end -->
