### PR TITLE
common: allow PMDK to be installed in custom path...

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-# Copyright 2017, Intel Corporation
+# Copyright 2017-2018, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -97,11 +97,15 @@ else ()
 		pkg_check_modules(Libpmemlog REQUIRED libpmemlog)
 		pkg_check_modules(Libpmemobj REQUIRED libpmemobj)
 		pkg_check_modules(Libpmempool REQUIRED libpmempool)
+		include_directories(${Libpmemblk_INCLUDE_DIRS} ${Libpmemlog_INCLUDE_DIRS} ${Libpmemobj_INCLUDE_DIRS} ${Libpmempool_INCLUDE_DIRS})
+		link_directories(${Libpmemblk_LIBRARY_DIRS} ${Libpmemlog_LIBRARY_DIRS} ${Libpmemobj_LIBRARY_DIRS} ${Libpmempool_LIBRARY_DIRS})
 	else ()
 		find_library(Libpmemblk "pmemblk")
 		find_library(Libpmemlog "pmemlog")
 		find_library(Libpmemobj "pmemobj")
 		find_library(Libpmempool "pmempool")
+		include_directories(${CMAKE_PREFIX_PATH}/include)
+		include_directories(${CMAKE_PREFIX_PATH}/lib)
 	endif ()
 endif ()
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,17 @@ For building a specific group of tests provide its target binary name:
 	$ make PMEMPOOLS
 ```
 
+##### PMDK Custom path
+If PMDK is installed in custom path, then additional arguments need to be specified.
+If pkg-config is available, then PKG_CONFIG_PATH environmental variable needs to be set to <PMDK_INSTALL_PATH>/lib/pkgconfig.
+```
+	$ PKG_CONFIG_PATH=<PMDK_INSTALL_PATH>/lib/pkgconfig cmake ..
+```
+If it's not available, then CMAKE_PREFIX_PATH needs to be specified. Relative paths are not supported with CMAKE_PREFIX_PATH.
+```
+	$ cmake .. -DCMAKE_PREFIX_PATH=<PMDK_INSTALL_PATH>
+```
+
 #### Building pmdk-tests on Windows ####
 Environment variables should be set according to [PMDK Windows installation guide](https://github.com/pmem/pmdk/tree/master/src/windows/setup#pmdk-for-windows-installation).
 


### PR DESCRIPTION
...previously 'make' would complain about missing headers

If pkg-config is available, then you need to specify PKG_CONFIG_PATH environmental variable.
If it's not available then you need to specify CMAKE_PREFIX_PATH when running CMake: cmake .. -DCMAKE_PREFIX_PATH=<path>
CMAKE_PREFIX_PATH does not support relative paths

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk-tests/9)
<!-- Reviewable:end -->
