### PR TITLE
common: pass CMAKE_C_COMPILER to GoogleTest and pugiXML

### DIFF
--- a/functions.cmake
+++ b/functions.cmake
@@ -1,5 +1,5 @@
 #
-# Copyright 2017, Intel Corporation
+# Copyright 2017-2018, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -76,7 +76,7 @@ function(download_gtest)
 		DOWNLOAD_DIR ${CMAKE_SOURCE_DIR}/ext/gtest
 		PREFIX ${CMAKE_CURRENT_BINARY_DIR}/ext/gtest
 		INSTALL_COMMAND ""
-		CMAKE_ARGS -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER} ${FORCE_SHARED_CRT_WINDOWS} ${BUILD_FLAGS_WINDOWS} ${BUILD_TYPE_LINUX}
+		CMAKE_ARGS -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER} -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER} ${FORCE_SHARED_CRT_WINDOWS} ${BUILD_FLAGS_WINDOWS} ${BUILD_TYPE_LINUX}
 	)
 	ExternalProject_Get_Property(gtest source_dir binary_dir)
 	add_library(libgtest IMPORTED STATIC GLOBAL)
@@ -128,7 +128,7 @@ function(download_pugixml)
 		DOWNLOAD_DIR ${CMAKE_SOURCE_DIR}/ext/pugixml
 		PREFIX ${CMAKE_CURRENT_BINARY_DIR}/ext/pugixml
 		INSTALL_COMMAND ""
-		CMAKE_ARGS -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER} ${BUILD_FLAGS_WINDOWS} ${BUILD_TYPE_LINUX}
+		CMAKE_ARGS -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER} -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER} ${BUILD_FLAGS_WINDOWS} ${BUILD_TYPE_LINUX}
 	)
 	ExternalProject_Get_Property(pugixml source_dir binary_dir)
 	add_library(libpugixml IMPORTED STATIC GLOBAL)


### PR DESCRIPTION
While this is not entirely necessary it fixes confusing message about selected compiler.

```
$ cmake .. -DCMAKE_CXX_COMPILER=g++-4.8 -DCMAKE_C_COMPILER=gcc-4.8
-- The C compiler identification is GNU 4.8.5
-- The CXX compiler identification is GNU 4.8.5
```
```
$ make
[ 15%] Performing configure step for 'gtest'
-- The C compiler identification is GNU 7.2.1
-- The CXX compiler identification is GNU 4.8.5
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk-tests/10)
<!-- Reviewable:end -->
