### PR TITLE
utils: fix ApiC::ReadFile

### DIFF
--- a/src/utils/api_c/api_c.cc
+++ b/src/utils/api_c/api_c.cc
@@ -38,6 +38,9 @@
 
 #include "api_c.h"
 
+#include <fstream>
+#include <sstream>
+
 int ApiC::CreateFileT(const std::string &path, const std::string &content) {
   std::ofstream file{path, std::ios::binary};
 
@@ -63,18 +66,16 @@ int ApiC::CreateFileT(const std::string &path,
 }
 
 int ApiC::ReadFile(const std::string &path, std::string &content) {
-  std::ifstream file{path, std::ios::binary | std::ios::ate};
+  std::ifstream file{path};
 
   if (!file.good()) {
     std::cerr << "File opening failed" << std::endl;
     return -1;
   }
 
-  std::string line;
-
-  while (std::getline(file, line)) {
-    content += line;
-  }
+  std::stringstream buffer;
+  buffer << file.rdbuf();
+  content = buffer.str();
 
   return 0;
 }

--- a/src/utils/api_c/api_c.h
+++ b/src/utils/api_c/api_c.h
@@ -34,7 +34,6 @@
 #define PMDK_TESTS_SRC_UTILS_API_C_API_C_H_
 
 #include <sys/stat.h>
-#include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>


### PR DESCRIPTION
Issues with current implentation:

1. std::ios::binary reading to std::string?
2. std::ios::ate sets offset to end of the file and isn't changed anywhere else
3. std::getline removes newline character
4. content += line <- where is newline? Also we'd have to detect on which platform we are - "\n" for Linux; "\r\n" for Windows

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk-tests/15)
<!-- Reviewable:end -->
