### PR TITLE
obj: ctl alloc classes - handle alignment field

### DIFF
--- a/src/tests/pmemobj/obj_ctl/alloc_class/alloc_class_utils.cc
+++ b/src/tests/pmemobj/obj_ctl/alloc_class/alloc_class_utils.cc
@@ -37,15 +37,17 @@ namespace AllocClassUtils {
 namespace {
 void printArg(const pobj_alloc_class_desc &arg) {
   std::cout << "Unit size: " << arg.unit_size << std::endl;
+  std::cout << "Alignment: " << arg.alignment << std::endl;
   std::cout << "Units per block: " << arg.units_per_block << std::endl;
   std::cout << "Header type: " << hdrs[arg.header_type].full_name << std::endl;
   std::cout << "Class ID: " << arg.class_id << std::endl;
 }
-}
+}  // namespace
 bool IsAllocClassValid(const pobj_alloc_class_desc &write,
                        const pobj_alloc_class_desc &read) {
   const unsigned bitmap_size = 2432;
   bool ret = write.class_id == read.class_id &&
+             write.alignment == read.alignment &&
              write.header_type == read.header_type &&
              write.unit_size == read.unit_size &&
              (write.units_per_block > bitmap_size
@@ -59,4 +61,4 @@ bool IsAllocClassValid(const pobj_alloc_class_desc &write,
   }
   return ret;
 }
-}
+}  // namespace AllocClassUtils

--- a/src/tests/pmemobj/obj_ctl/alloc_class/alloc_class_utils.h
+++ b/src/tests/pmemobj/obj_ctl/alloc_class/alloc_class_utils.h
@@ -33,8 +33,8 @@
 #ifndef PMDK_ALLOC_CLASS_UTILS_H
 #define PMDK_ALLOC_CLASS_UTILS_H
 
-#include <array>
 #include <libpmemobj.h>
+#include <array>
 #include <string>
 
 namespace AllocClassUtils {
@@ -44,10 +44,11 @@ struct hdr_desc {
   size_t size;
 };
 
-const std::array<hdr_desc, MAX_POBJ_HEADER_TYPES> hdrs = {
+const std::array<hdr_desc, MAX_POBJ_HEADER_TYPES + 1> hdrs = {
     {{"POBJ_HEADER_LEGACY", "legacy", 64},
      {"POBJ_HEADER_COMPACT", "compact", 16},
-     {"POBJ_HEADER_NONE", "none", 0}}};
+     {"POBJ_HEADER_NONE", "none", 0},
+     {"MAX_POBJ_HEADER_TYPES", "invalid", 0}}};
 
 /*
  * IsAllocClassValid -- checks if created allocation class described by read is
@@ -57,6 +58,6 @@ const std::array<hdr_desc, MAX_POBJ_HEADER_TYPES> hdrs = {
  */
 bool IsAllocClassValid(const pobj_alloc_class_desc &write,
                        const pobj_alloc_class_desc &read);
-}
+}  // namespace AllocClassUtils
 
-#endif // PMDK_ALLOC_CLASS_UTILS_H
+#endif  // PMDK_ALLOC_CLASS_UTILS_H

--- a/src/tests/pmemobj/obj_ctl/alloc_class/ext_cfg.cc
+++ b/src/tests/pmemobj/obj_ctl/alloc_class/ext_cfg.cc
@@ -67,12 +67,14 @@ std::string ObjCtlExtCfgTest::ToCtlString(
   query +=
       desc.class_id == auto_class_id ? "new" : std::to_string(desc.class_id);
   query += ".desc=" + std::to_string(desc.unit_size) + "," +
+           std::to_string(desc.alignment) + "," +
            std::to_string(desc.units_per_block) + "," +
            AllocClassUtils::hdrs[desc.header_type].config_name + ";";
   return query;
 }
 
 int ObjCtlExtCfgTest::GetAllocClassId(PMEMobjpool *pop, size_t unit_size,
+                                      size_t alignment,
                                       unsigned units_per_block,
                                       pobj_header_type header_type) const {
   int id = -1;
@@ -80,7 +82,7 @@ int ObjCtlExtCfgTest::GetAllocClassId(PMEMobjpool *pop, size_t unit_size,
   for (int i = 0; i < 255; ++i) {
     std::string entry_point = "heap.alloc_class." + std::to_string(i) + ".desc";
     if (pmemobj_ctl_get(pop, entry_point.c_str(), &arg) == 0) {
-      if (arg.unit_size == unit_size &&
+      if (arg.unit_size == unit_size && arg.alignment == alignment &&
           arg.units_per_block == units_per_block &&
           arg.header_type == header_type) {
         id = arg.class_id;

--- a/src/tests/pmemobj/obj_ctl/alloc_class/ext_cfg.h
+++ b/src/tests/pmemobj/obj_ctl/alloc_class/ext_cfg.h
@@ -63,9 +63,9 @@ class ObjCtlExtCfgTest : public ::testing::TestWithParam<
    */
   std::string ToCtlString(const pobj_alloc_class_desc &desc) const;
   /* GetAllocClassId -- returns class id of the allocation class within pop pool
-   * described by unit_size, units_per_block, header_type arguments.
+   * described by unit_size, alignment, units_per_block, header_type arguments.
    * Returns -1 if allocation class does not exist. */
-  int GetAllocClassId(PMEMobjpool *pop, size_t unit_size,
+  int GetAllocClassId(PMEMobjpool *pop, size_t unit_size, size_t alignment,
                       unsigned units_per_block,
                       pobj_header_type header_type) const;
   virtual void SetUp();


### PR DESCRIPTION
Changes due to alignment field added to pobj_alloc_class_desc struct.
Negative tests for this field added.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk-tests/27)
<!-- Reviewable:end -->
