### PR TITLE
obj_ctl: write args explicitly to avoid compiling errors

### DIFF
--- a/src/tests/pmemobj/obj_ctl/alloc_class/alloc_class_test.cc
+++ b/src/tests/pmemobj/obj_ctl/alloc_class/alloc_class_test.cc
@@ -537,8 +537,9 @@ INSTANTIATE_TEST_CASE_P(
                                 out_args{-1, EEXIST})));
 INSTANTIATE_TEST_CASE_P(
     RetrieveInfoFromUnexistingClass, ObjCtlAllocClassParamTest,
-    ::testing::Values(make_pair(in_args{{{}, {}, {}, {}, 128}, Scenario::GET},
-                                out_args{-1, ENOENT})));
+    ::testing::Values(make_pair(
+        in_args{{512, 0, 1024, POBJ_HEADER_COMPACT, 128}, Scenario::GET},
+        out_args{-1, ENOENT})));
 INSTANTIATE_TEST_CASE_P(
     CreateCustomAllocationClass, ObjCtlAllocClassParamTest,
     ::testing::Values(


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk-tests/34)
<!-- Reviewable:end -->
