### PR TITLE
common: enable succesful clang compilation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,6 +50,7 @@ include(FindThreads)
 include(functions.cmake) # Function definitions
 
 option(DEVELOPER_MODE "enable developer checks" OFF)
+option(PMDK_SYSTEM_HEADERS "always treat PMDK headers as system headers" ON)
 include(style-format.cmake)
 
 # Find and set GTest, PugiXML and PMDK libraries paths
@@ -111,6 +112,20 @@ else ()
 				${Libpmemlog_INCLUDE_DIRS}
 				${Libpmemobj_INCLUDE_DIRS}
 				${Libpmempool_INCLUDE_DIRS})
+
+		if (PMDK_SYSTEM_HEADERS)
+			set(CMAKE_CXX_FLAGS
+				"${CMAKE_CXX_FLAGS} -isystem ${Libpmem_INCLUDE_DIRS}")
+			set(CMAKE_CXX_FLAGS
+				"${CMAKE_CXX_FLAGS} -isystem ${Libpmemblk_INCLUDE_DIRS}")
+			set(CMAKE_CXX_FLAGS
+				"${CMAKE_CXX_FLAGS} -isystem ${Libpmemlog_INCLUDE_DIRS}")
+			set(CMAKE_CXX_FLAGS
+				"${CMAKE_CXX_FLAGS} -isystem ${Libpmemobj_INCLUDE_DIRS}")
+			set(CMAKE_CXX_FLAGS
+				"${CMAKE_CXX_FLAGS} -isystem ${Libpmempool_INCLUDE_DIRS}")
+		endif ()
+
 		link_directories(${Libpmem_LIBRARY_DIRS}
 				${Libpmemblk_LIBRARY_DIRS}
 				${Libpmemlog_LIBRARY_DIRS}
@@ -126,6 +141,11 @@ else ()
 
 		find_path(PMDK_INCLUDE_DIR NAMES "libpmem.h" "libpmemblk.h" "libpmemlog.h" "libpmemobj.h" "libpmempool.h")
 		include_directories(${PMDK_INCLUDE_DIR})
+		if (PMDK_SYSTEM_HEADERS)
+			set(CMAKE_CXX_FLAGS
+				"${CMAKE_CXX_FLAGS} -isystem ${PMDK_INCLUDE_DIR}")
+		endif ()
+
 	endif ()
 endif ()
 

--- a/functions.cmake
+++ b/functions.cmake
@@ -180,5 +180,12 @@ function(check_workaround_flags_required)
 		set(WORKAROUND_FLAGS "${WORKAROUND_FLAGS} -D_GLIBCXX_USE_C99")
 	endif ()
 
+	if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+		# Removing problematic clang++ flags:
+		# 1. https://github.com/google/googletest/issues/1419
+		# 2. https://bugs.llvm.org/show_bug.cgi?id=21629
+		set(WORKAROUND_FLAGS "${WORKAROUND_FLAGS} -Wno-missing-braces -Wno-gnu-zero-variadic-macro-arguments")
+	endif()
+
 	set(WORKAROUND_FLAGS "${WORKAROUND_FLAGS}" PARENT_SCOPE)
 endfunction()

--- a/src/tests/ras/unsafe_shutdown/unsafe_shutdown.cc
+++ b/src/tests/ras/unsafe_shutdown/unsafe_shutdown.cc
@@ -74,7 +74,8 @@ int UnsafeShutdown::PmempoolRepair(std::string pool_file_path) const {
     switch (status->type) {
       case PMEMPOOL_CHECK_MSG_TYPE_ERROR:
       case PMEMPOOL_CHECK_MSG_TYPE_INFO:
-        status_msg.append(status->str.msg + '\n');
+        status_msg.append(status->str.msg);
+        status_msg.append("\n");
         break;
       default:
         pmempool_check_end(ppc);

--- a/src/tests/ras/utils/test_phase/local_test_phase.cc
+++ b/src/tests/ras/utils/test_phase/local_test_phase.cc
@@ -44,12 +44,12 @@ LocalTestPhase::LocalTestPhase() {
   int i = 0;
   std::copy_if(config_.begin(), config_.end(),
                std::back_inserter(unsafe_namespaces),
-               [&i, this](DimmNamespace) -> bool { return i++ != 1; });
+               [&i](DimmNamespace) -> bool { return i++ != 1; });
 
   i = 0;
   std::copy_if(config_.begin(), config_.end(),
                std::back_inserter(safe_namespaces),
-               [&i, this](DimmNamespace) -> bool { return i++ == 1; });
+               [&i](DimmNamespace) -> bool { return i++ == 1; });
 }
 
 int LocalTestPhase::Begin() const {

--- a/src/tests/ras/utils/test_phase/remote_test_phase.cc
+++ b/src/tests/ras/utils/test_phase/remote_test_phase.cc
@@ -175,7 +175,7 @@ const std::vector<std::string> RemoteTestPhase::GetSafeMountpoints(
   std::vector<std::string> ret;
   int i = 0;
   std::copy_if(node.begin(), node.end(), std::back_inserter(ret),
-               [&i, this](std::string) -> bool { return i++ == 1; });
+               [&i](std::string) -> bool { return i++ == 1; });
   return ret;
 }
 
@@ -184,7 +184,7 @@ const std::vector<std::string> RemoteTestPhase::GetUnsafeMountpoints(
   std::vector<std::string> ret;
   int i = 0;
   std::copy_if(node.begin(), node.end(), std::back_inserter(ret),
-               [&i, this](std::string) -> bool { return i++ != 1; });
+               [&i](std::string) -> bool { return i++ != 1; });
   return ret;
 }
 


### PR DESCRIPTION
1. remove problematic warning flags
2. fix error found by clang in existing code
3. treat pmdk headers as system headers by default (controlled with PMDK_SYSTEM_HEADERS cmake option)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk-tests/44)
<!-- Reviewable:end -->
