### PR TITLE
add exceptions for arena docs

### DIFF
--- a/src/tests/scripts/split_manpage/exceptions.txt
+++ b/src/tests/scripts/split_manpage/exceptions.txt
@@ -59,3 +59,5 @@ pobj_max_actions
 pobj_action_xreserve_valid_flags
 libpmemobj_types_h
 pmemvlt
+pobj_arena_id
+pobj_xalloc_arena_mask


### PR DESCRIPTION
Adding 2 new exceptions in documentations checks for recent changes around arenas:
* pobj_arena_id
* pobj_xalloc_arena_mask

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk-tests/61)
<!-- Reviewable:end -->
