### PR TITLE
scripts: Add flags to exceptions.txt

### DIFF
--- a/src/tests/scripts/split_manpage/exceptions.txt
+++ b/src/tests/scripts/split_manpage/exceptions.txt
@@ -64,3 +64,5 @@ pobj_xalloc_arena_mask
 pmdk_use_attr_deprec_with_msg
 pobj_flag_no_snapshot
 pobj_xadd_no_snapshot
+pobj_flag_assume_initialized
+pobj_xadd_assume_initialized


### PR DESCRIPTION
Add 'pobj_xadd_assume_initialized' and 'pobj_flag_assume_initialized' to exceptions.txt in the script which tests man page.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk-tests/69)
<!-- Reviewable:end -->
