### PR TITLE
Fix config's README and example

### DIFF
--- a/etc/config/README.md
+++ b/etc/config/README.md
@@ -11,9 +11,9 @@ Config file consists of multiple main sections (xml tags):
 
 ### localConfiguration structure ###
 * `testDir`: path to test execution directory. If `dimmConfiguration` section
-* is defined, it should represent a mountpoint of non-NVDIMM device.
+is defined, it should represent a mountpoint of non-NVDIMM device.
 * `dimmConfiguration`: NVDIMM devices configuration section
-    * `mountPoint`: path to mountpoint associated with single bus connected with
+	* `mountPoint`: path to mountpoint associated with single bus connected with
 one or more NVDIMMS
 
 ### remoteConfiguration structure ###
@@ -29,9 +29,8 @@ authenticate without further quering.
 
 ### rasConfiguration structure ###
 * `DUT` - node representing single testing machine managed by controller
-    * `address`: DUT address
-    * `powerCycleCommand`: command triggering DUT power cycle
-    * `binDir`: DUT test binaries directory
-
+	* `address`: DUT address
+	* `powerCycleCommand`: command triggering DUT power cycle
+	* `binDir`: DUT test binaries directory
 
 See also: config.xml [example file](config.xml.example).

--- a/etc/config/config.xml.example
+++ b/etc/config/config.xml.example
@@ -1,13 +1,4 @@
 <configuration>
-	<rasConfiguration>
-                <phasesCount>2</phasesCount>
-                <DUT>
-                        <address>[<user>@]<hostname>[:<port>]</address>
-                        <powerCycleCommand>script</powerCycleCommand>
-                        <binDir>example\path</binDir>
-                        <injectPolicy>all</injectPolicy>
-                </DUT>
-        </rasConfiguration>
 	<localConfiguration>
 		<testDir>example\path</testDir>
 		<dimmConfiguration>
@@ -15,6 +6,15 @@
 			<mountPoint>example\path2</mountPoint>
 		</dimmConfiguration>
 	</localConfiguration>
+	<rasConfiguration>
+		<phasesCount>2</phasesCount>
+		<DUT>
+			<address>[<user>@]<hostname>[:<port>]</address>
+			<powerCycleCommand>script</powerCycleCommand>
+			<binDir>example\path</binDir>
+			<injectPolicy>all</injectPolicy>
+		</DUT>
+	</rasConfiguration>
 	<remoteConfiguration>
 		<testDir>example\path</testDir>
 		<address>[<user>@]<hostname>[:<port>]</address>


### PR DESCRIPTION
* changed spaces to tabs,
* removed one README list element, since it's mistakenly added,
* changed order of config's items in example, so local_config is the first one.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk-tests/71)
<!-- Reviewable:end -->
